### PR TITLE
Web 11095

### DIFF
--- a/lib/harvest.js
+++ b/lib/harvest.js
@@ -38,6 +38,9 @@
     }
 
     var initialVersionKey = _generateVersionKey()
+    if (sharedBasket.version) {
+      initialVersionKey = sharedBasket.version
+    }
     storedBasket.tags.initial = initialVersionKey
     storedBasket.versions[initialVersionKey] = {
       base: null,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harvest",
   "description": "Basket Management tool for Shortbreaks",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "homepage": "https://github.com/holidayextras/harvest",
   "author": {
     "name": "Shortbreaks",


### PR DESCRIPTION
#### What does this PR do? (please provide any background)

[WEB-11095](https://hxshortbreaks.atlassian.net/browse/WEB-11095)

if we passed in `version` into `harvest.createBasket` we now consume it overwriting the version generated from `_ _generateVersionKey()`

#### What tests does this PR have?

#### How can this be tested?

see https://github.com/holidayextras/the-works/pull/540

#### Any tech debt?

#### Screenshots / Screencast

#### What gif best describes how you feel about this work?
![]()

- I have checked our general [contributing document](https://github.com/holidayextras/culture/blob/master/CONTRIBUTING.md) and the project specific [contributing document](../blob/master/CONTRIBUTING.md) (if present) and I'm happy for this to be reviewed.

By approving a review you are confirming you have...
- Witnessed the work behaving as expected (this could be on the author's machine or screencast).
- Checked for coding anti-patterns.
- Checked for appropriate test coverage.
- Checked all the tests are passing.

---
